### PR TITLE
Update selector

### DIFF
--- a/ing.ts
+++ b/ing.ts
@@ -4,7 +4,7 @@ import { minorUnitDecimals, stringAmount } from './currency';
 
 export const decimalSeparator = '.';
 export const decimalCount = 2;
-export const statementSelector = `[data-tag-name="ing-ow-expandable-item"]`;
+export const statementSelector = `ing-ow-expandable-item`;
 export const csvHeaderLine = `Date,Description,Currency,Amount,Exchange rate,Original currency,Original amount,Conversion fee\n`;
 // ING‌ outputs a correct minus sign. Javascript only parses hyphens (word break characters) as negative prefix in numbers. Took me a LONG time to figure that out.
 export const minusSign = '−';


### PR DESCRIPTION
It looks like they changed the HTML, and at least in Chrome 135 a saved page doesn't work with the `data` attribute selector anymore. The bare tag works fine.

In an export I did today, the tags look like:

```
<ing-ow-expandable-item class="expandable-item  expandable-y53ustqlkb "><template shadowrootmode="open"><!---->
```